### PR TITLE
afl: Fix afl-qemu build by applying new patches

### DIFF
--- a/qemu_mode/patches/syscall.diff
+++ b/qemu_mode/patches/syscall.diff
@@ -1,6 +1,14 @@
---- qemu-2.10.0-rc3-clean/linux-user/syscall.c	2017-08-15 11:39:41.000000000 -0700
-+++ qemu-2.10.0-rc3/linux-user/syscall.c	2017-08-22 14:34:03.193088186 -0700
-@@ -116,6 +116,8 @@
+--- qemu-2.10.0-clean/linux-user/syscall.c	2020-03-12 18:47:47.898592169 +0100
++++ qemu-2.10.0/linux-user/syscall.c	2020-03-12 19:16:41.563074307 +0100
+@@ -34,6 +34,7 @@
+ #include <sys/resource.h>
+ #include <sys/swap.h>
+ #include <linux/capability.h>
++#include <linux/sockios.h> // https://lkml.org/lkml/2019/6/3/988
+ #include <sched.h>
+ #include <sys/timex.h>
+ #ifdef __ia64__
+@@ -116,6 +117,8 @@ int __clone2(int (*fn)(void *), void *ch
  
  #include "qemu.h"
  
@@ -9,13 +17,57 @@
  #ifndef CLONE_IO
  #define CLONE_IO                0x80000000      /* Clone io context */
  #endif
-@@ -11688,8 +11690,21 @@
+@@ -256,7 +259,9 @@ static type name (type1 arg1,type2 arg2,
+ #endif
+ 
+ #ifdef __NR_gettid
+-_syscall0(int, gettid)
++// taken from https://patchwork.kernel.org/patch/10862231/
++#define __NR_sys_gettid __NR_gettid
++_syscall0(int, sys_gettid)
+ #else
+ /* This is a replacement for the host gettid() and must return a host
+    errno. */
+@@ -6219,7 +6224,8 @@ static void *clone_func(void *arg)
+     cpu = ENV_GET_CPU(env);
+     thread_cpu = cpu;
+     ts = (TaskState *)cpu->opaque;
+-    info->tid = gettid();
++    // taken from https://patchwork.kernel.org/patch/10862231/
++    info->tid = sys_gettid();
+     task_settid(ts);
+     if (info->child_tidptr)
+         put_user_u32(info->tid, info->child_tidptr);
+@@ -6363,9 +6369,11 @@ static int do_fork(CPUArchState *env, un
+                mapping.  We can't repeat the spinlock hack used above because
+                the child process gets its own copy of the lock.  */
+             if (flags & CLONE_CHILD_SETTID)
+-                put_user_u32(gettid(), child_tidptr);
++                // taken from https://patchwork.kernel.org/patch/10862231/
++                put_user_u32(sys_gettid(), child_tidptr);
+             if (flags & CLONE_PARENT_SETTID)
+-                put_user_u32(gettid(), parent_tidptr);
++                // taken from https://patchwork.kernel.org/patch/10862231/
++                put_user_u32(sys_gettid(), parent_tidptr);
+             ts = (TaskState *)cpu->opaque;
+             if (flags & CLONE_SETTLS)
+                 cpu_set_tls (env, newtls);
+@@ -11402,7 +11410,8 @@ abi_long do_syscall(void *cpu_env, int n
+         break;
+ #endif
+     case TARGET_NR_gettid:
+-        ret = get_errno(gettid());
++        // taken from https://patchwork.kernel.org/patch/10862231/
++        ret = get_errno(sys_gettid());
+         break;
+ #ifdef TARGET_NR_readahead
+     case TARGET_NR_readahead:
+@@ -11688,8 +11697,20 @@ abi_long do_syscall(void *cpu_env, int n
          break;
  
      case TARGET_NR_tgkill:
 -        ret = get_errno(safe_tgkill((int)arg1, (int)arg2,
 -                        target_to_host_signal(arg3)));
-+
 +        {
 +          int pid  = (int)arg1,
 +              tgid = (int)arg2,


### PR DESCRIPTION
These patches are gathered from different sources,
see also below.
The other patch is required because some implicitly included
files are not included anymore, requiring an explicit include
of <linux/sockios.h>.
This solves issue #41.

Build errors include: SIOCGSTAMP not declared,
  SIOCGSTAMPNS not declared and `static declaration of ‘gettid’ follows non-static declaration`

See also:
- https://github.com/qemu/qemu/commit/71ba74f67eaca21b0cc9d96f534ad3b9a7161400
- https://github.com/qemu/qemu/commit/6d5d5dde9adb5acb32e6b8e3dfbf47fff0f308d2
- https://lkml.org/lkml/2019/6/3/988
- https://patchwork.kernel.org/patch/10862231/